### PR TITLE
fix: footer stays at bottom on short pages (#68)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,9 +31,11 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
-          {children}
-          <NavBar />
-          <Footer />
+          <div className="flex min-h-screen flex-col"> 
+            <NavBar />
+            <main className="flex-1 pt-20">{children}</main>
+            <Footer />
+          </div>
         </Providers>
       </body>
     </html>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import HeroSection from "@/components/hero-section";
 
 export default function Home() {
   return (
-    <main>
+    <div>
       <HeroSection />
       <section className="py-20 bg-gray-50 ml-5 mr-5">
         <div className="flex w-full justify-center">
@@ -71,6 +71,6 @@ export default function Home() {
           </div>
         </div>
       </section>
-    </main>
+    </div>
   );
 }


### PR DESCRIPTION
Fixes #68

Updated the root layout to ensure the page fills the viewport height,
so the footer remains at the bottom of the screen when the page content
is shorter than the viewport (e.g. /about-us).