### PR TITLE
move db query get-current-user to app/api/user

### DIFF
--- a/src/app/api/user/get-current-user.ts
+++ b/src/app/api/user/get-current-user.ts
@@ -1,0 +1,12 @@
+import { users } from "@/db";
+import { db } from "@/db/db";
+import { eq } from "drizzle-orm";
+
+export  async function getUserByEmail(email: string) {
+
+  const result = await db.query.users.findFirst({
+    where: eq(users.email, email),
+  });
+  return result;
+
+}

--- a/src/lib/auth/getCurrentUser.ts
+++ b/src/lib/auth/getCurrentUser.ts
@@ -7,6 +7,7 @@ import { eq } from "drizzle-orm";
 import type { CurrentUser } from "@/types/CurrentUser";
 import { mapUserToCurrentUser } from "./mapUserToCurrentUser";
 import { authOptions } from "./auth-options";
+import { getUserByEmail } from "@/app/api/user/get-current-user";
 
 export async function getCurrentUser(): Promise<CurrentUser | null> {
   const session = await getServerSession(authOptions);
@@ -15,9 +16,8 @@ export async function getCurrentUser(): Promise<CurrentUser | null> {
     return null;
   }
 
-  const user = await db.query.users.findFirst({
-    where: eq(users.email, session.user.email),
-  });
+  const user = await getUserByEmail(session.user.email);
+ 
 
   if (!user) {
     return null;


### PR DESCRIPTION
import { users } from "@/db";
import { db } from "@/db/db";
import { eq } from "drizzle-orm";

export  async function getUserByEmail(email: string) {

  const result = await db.query.users.findFirst({
    where: eq(users.email, email),
  });
  return result;
