### PR TITLE
fix(bikes): restore API shape to fix catalog break

### DIFF
--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -23,7 +23,17 @@ export default function AdminPanel() {
   const loadBikes = async () => {
     const res = await fetch("/api/bikes");
     const data = await res.json();
-    setBikes(data);
+
+    const adminBikes = data.map((bike: any) => ({
+      id: bike.id,
+      name: `${bike.brand ?? ""} ${bike.model ?? ""}`.trim(),
+      type: bike.category?.name || "No Category",
+      price: Number(bike.pricePerDay),
+      status: bike.isActive ? "available" : "busy",
+      image: bike.image ?? null,
+    }));
+
+    setBikes(adminBikes);
   };
 
   useEffect(() => {

--- a/src/services/bikes.service.ts
+++ b/src/services/bikes.service.ts
@@ -15,12 +15,15 @@ export const bikesService = {
         .leftJoin(categories, eq(bikes.bikeCategoryId, categories.id));
 
       return result.map(({ bike, category }) => ({
-        id: bike.id,
-        name: `${bike.brand ?? ""} ${bike.model ?? ""}`.trim(),
-        type: category?.name || "No Category",
-        price: Number(bike.pricePerDay),
-        status: bike.isActive ? "available" : "busy",
-        image: bike.image ?? null,
+        ...bike,
+        pricePerDay: Number(bike.pricePerDay),
+        category: category
+          ? { ...category }
+          : {
+              id: "",
+              name: "No Category",
+              description: null,
+            },
       }));
     } catch (error) {
       console.error("Error loading bikes:", error);


### PR DESCRIPTION
Problem:
Catalog page stopped displaying bikes after changes in admin bikes flow.

Root cause:
Shared API (/api/bikes) format was modified, which affected catalog.

Changes:
- Restored expected API shape for bikes
- Adjusted admin usage to avoid breaking shared API

Notes:
Local verification is limited due to DB connection issue (Supabase auth).
Please verify:
- /catalog page
- bikes API response

Related:
#122
#125