### PR TITLE
[ADMIN-142] WIP: Refactor admin layout with persistent sidebar

### DIFF
--- a/src/app/admin/accessories/page.tsx
+++ b/src/app/admin/accessories/page.tsx
@@ -52,15 +52,6 @@ export default function AdminAccessoriesPage() {
   return (
     <div className="m-10 container mx-auto py-10">
       <div className="flex items-center mb-6">
-        <button
-          className="mr-4 flex items-center text-sm font-bold text-gray-400 hover:text-black transition-colors group uppercase"
-          onClick={() => (window.location.href = "/admin")}
-        >
-          <span className="mr-2 transition-transform group-hover:-translate-x-1">
-            ←
-          </span>
-          Back to Admin Panel
-        </button>
         <h1 className="text-3xl font-bold">Accessories</h1>
       </div>
       <div className="mb-6 flex gap-6">

--- a/src/app/admin/accessories/page.tsx
+++ b/src/app/admin/accessories/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import React from "react";
+import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export default function AdminAccessoriesPage() {
   const [accessories, setAccessories] = useState([]);
@@ -50,89 +51,95 @@ export default function AdminAccessoriesPage() {
   }, []);
 
   return (
-    <div className="m-10 container mx-auto py-10">
-      <div className="flex items-center mb-6">
-        <h1 className="text-3xl font-bold">Accessories</h1>
-      </div>
-      <div className="mb-6 flex gap-6">
-        <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
-          Total Accessories: {accessories.length}
+    <div>
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr] items-start m-10 container mx-auto py-10">
+        <div className="self-start">
+          <AdminSidebar />
         </div>
-        {/* Poți adăuga aici alte statistici dacă vrei */}
-      </div>
-      <table className="w-full text-left border border-gray-200 rounded-xl bg-white">
-        <thead className="bg-gray-50 text-sm text-gray-600">
-          <tr>
-            <th className="px-6 py-4">Name</th>
-            <th className="px-6 py-4">Price/Day</th>
-            <th className="px-6 py-4">Actions</th>
-          </tr>
-        </thead>
-        <tbody className="divide-y divide-gray-200">
-          {accessories.map((acc: any) => (
-            <tr key={acc.id} className="text-sm text-gray-700">
-              <td className="px-6 py-4">{acc.name}</td>
-              <td className="px-6 py-4">€{acc.pricePerDay}</td>
-              <td className="px-6 py-4">
-                <button
-                  className="mr-2 text-blue-600"
-                  onClick={() => handleEditAccessory(acc)}
-                >
-                  ✏️
-                </button>
-                <button
-                  className="text-red-600"
-                  onClick={() => handleDeleteAccessory(acc.id)}
-                >
-                  🗑️
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-      {editModalOpen && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
-          <form
-            className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md"
-            onSubmit={handleEditSubmit}
-          >
-            <h2 className="text-xl font-bold mb-4">Edit Accessory</h2>
-            <input
-              name="name"
-              value={editForm.name || ""}
-              onChange={handleEditChange}
-              placeholder="Name"
-              className="mb-2 w-full border p-2 rounded"
-              required
-            />
-            <input
-              name="price_per_day"
-              value={editForm.price_per_day || ""}
-              onChange={handleEditChange}
-              placeholder="Price per day"
-              type="number"
-              className="mb-2 w-full border p-2 rounded"
-              required
-            />
-            <div className="flex gap-2 mt-4">
-              <button
-                type="button"
-                className="bg-gray-300 px-4 py-2 rounded"
-                onClick={() => setEditModalOpen(false)}
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                className="bg-black text-white px-4 py-2 rounded"
-              >
-                Save
-              </button>
+
+        <div>
+          <div className="flex items-center mb-6">
+            <h1 className="text-3xl font-bold">Accessories</h1>
+          </div>
+          <div className="mb-6 flex gap-6">
+            <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
+              Total Accessories: {accessories.length}
             </div>
-          </form>
+          </div>
+          <table className="w-full text-left border border-gray-200 rounded-xl bg-white">
+            <thead className="bg-gray-50 text-sm text-gray-600">
+              <tr>
+                <th className="px-6 py-4">Name</th>
+                <th className="px-6 py-4">Price/Day</th>
+                <th className="px-6 py-4">Actions</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {accessories.map((acc: any) => (
+                <tr key={acc.id} className="text-sm text-gray-700">
+                  <td className="px-6 py-4">{acc.name}</td>
+                  <td className="px-6 py-4">€{acc.pricePerDay}</td>
+                  <td className="px-6 py-4">
+                    <button
+                      className="mr-2 text-blue-600"
+                      onClick={() => handleEditAccessory(acc)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className="text-red-600"
+                      onClick={() => handleDeleteAccessory(acc.id)}
+                    >
+                      Delete
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+
+          {editModalOpen && (
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+              <form
+                className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md"
+                onSubmit={handleEditSubmit}
+              >
+                <h2 className="text-xl font-bold mb-4">Edit Accessory</h2>
+                <input
+                  name="name"
+                  value={editForm.name || ""}
+                  onChange={handleEditChange}
+                  placeholder="Name"
+                  className="mb-2 w-full border p-2 rounded"
+                />
+                <input
+                  name="price_per_day"
+                  value={editForm.price_per_day || ""}
+                  onChange={handleEditChange}
+                  placeholder="Price per day"
+                  type="number"
+                  className="mb-2 w-full border p-2 rounded"
+                />
+                <div className="flex gap-2 mt-4">
+                  <button
+                    type="button"
+                    className="bg-gray-300 px-4 py-2 rounded"
+                    onClick={() => setEditModalOpen(false)}
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="submit"
+                    className="bg-black text-white px-4 py-2 rounded"
+                  >
+                    Save
+                  </button>
+                </div>
+              </form>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/src/app/admin/categories/new/page.tsx
+++ b/src/app/admin/categories/new/page.tsx
@@ -1,80 +1,87 @@
 import getAllCategories from "@/app/api/actions-category/read-all-categories";
 import createCategory from "@/app/api/actions-category/create-category";
+import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export default async function AddCategoryPage() {
   const categories = await getAllCategories();
 
   return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-3xl font-bold">Categories</h1>
-        <p className="text-gray-500">Create and review bike categories</p>
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr] items-start">
+      <div className="self-start">
+        <AdminSidebar />
       </div>
 
-      <div className="flex gap-6">
-        <div className="rounded-xl bg-gray-100 px-6 py-4 text-lg font-semibold">
-          Total Categories: {categories.length}
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold">Categories</h1>
+          <p className="text-gray-500">Create and review bike categories</p>
         </div>
-      </div>
 
-      <div className="rounded-xl border border-gray-200 bg-white p-6">
-        <h2 className="mb-4 text-xl font-bold">Add Category</h2>
-
-        <form action={createCategory} className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
-              Name
-            </label>
-            <input
-              name="name"
-              type="text"
-              placeholder="Category name"
-              className="w-full rounded border p-3"
-              required
-            />
+        <div className="flex gap-6">
+          <div className="rounded-xl bg-gray-100 px-6 py-4 text-lg font-semibold">
+            Total Categories: {categories.length}
           </div>
+        </div>
 
-          <div>
-            <label className="mb-2 block text-sm font-medium text-gray-700">
-              Image URL
-            </label>
-            <input
-              name="image"
-              type="text"
-              placeholder="https://example.com/category.jpg"
-              className="w-full rounded border p-3"
-              required
-            />
-          </div>
+        <div className="rounded-xl border border-gray-200 bg-white p-6">
+          <h2 className="mb-4 text-xl font-bold">Add Category</h2>
 
-          <div className="md:col-span-2">
-            <button
-              type="submit"
-              className="rounded bg-black px-5 py-3 text-white"
-            >
-              Create Category
-            </button>
-          </div>
-        </form>
-      </div>
+          <form action={createCategory} className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700">
+                Name
+              </label>
+              <input
+                name="name"
+                type="text"
+                placeholder="Category name"
+                className="w-full rounded border p-3"
+                required
+              />
+            </div>
 
-      <table className="w-full rounded-xl border border-gray-200 bg-white text-left">
-        <thead className="bg-gray-50 text-sm text-gray-600">
-          <tr>
-            <th className="px-6 py-4">Name</th>
-            <th className="px-6 py-4">Image</th>
-          </tr>
-        </thead>
+            <div>
+              <label className="mb-2 block text-sm font-medium text-gray-700">
+                Image URL
+              </label>
+              <input
+                name="image"
+                type="text"
+                placeholder="https://example.com/category.jpg"
+                className="w-full rounded border p-3"
+                required
+              />
+            </div>
 
-        <tbody className="divide-y divide-gray-200">
-          {categories.map((category) => (
-            <tr key={category.id} className="text-sm text-gray-700">
-              <td className="px-6 py-4">{category.name}</td>
-              <td className="break-all px-6 py-4">{category.image}</td>
+            <div className="md:col-span-2">
+              <button
+                type="submit"
+                className="rounded bg-black px-5 py-3 text-white"
+              >
+                Create Category
+              </button>
+            </div>
+          </form>
+        </div>
+
+        <table className="w-full rounded-xl border border-gray-200 bg-white text-left">
+          <thead className="bg-gray-50 text-sm text-gray-600">
+            <tr>
+              <th className="px-6 py-4">Name</th>
+              <th className="px-6 py-4">Image</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+
+          <tbody className="divide-y divide-gray-200">
+            {categories.map((category) => (
+              <tr key={category.id} className="text-sm text-gray-700">
+                <td className="px-6 py-4">{category.name}</td>
+                <td className="break-all px-6 py-4">{category.image}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/src/app/admin/categories/new/page.tsx
+++ b/src/app/admin/categories/new/page.tsx
@@ -1,53 +1,23 @@
-import Link from "next/link";
-import { redirect } from "next/navigation";
-import { getServerSession } from "next-auth";
-import { authOptions } from "@/lib/auth/auth-options";
-import { getUserByEmail } from "@/app/api/user/get-current-user";
 import getAllCategories from "@/app/api/actions-category/read-all-categories";
 import createCategory from "@/app/api/actions-category/create-category";
 
 export default async function AddCategoryPage() {
-  const session = await getServerSession(authOptions);
-
-  if (!session?.user?.email) {
-    redirect("/login");
-  }
-
-  const user = await getUserByEmail(session.user.email);
-
-  if (!user) {
-    redirect("/login");
-  }
-
-  if (user.role !== "ADMIN") {
-    redirect("/");
-  }
-
   const categories = await getAllCategories();
 
   return (
-    <main className="m-10 container mx-auto py-10">
-      <div className="flex items-center mb-6">
-        <Link
-          href="/admin"
-          className="mr-4 flex items-center text-sm font-bold text-gray-400 hover:text-black transition-colors group uppercase"
-        >
-          <span className="mr-2 transition-transform group-hover:-translate-x-1">
-            ←
-          </span>
-          Back to Admin Panel
-        </Link>
-
+    <div className="space-y-6">
+      <div>
         <h1 className="text-3xl font-bold">Categories</h1>
+        <p className="text-gray-500">Create and review bike categories</p>
       </div>
 
-      <div className="mb-6 flex gap-6">
-        <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
+      <div className="flex gap-6">
+        <div className="rounded-xl bg-gray-100 px-6 py-4 text-lg font-semibold">
           Total Categories: {categories.length}
         </div>
       </div>
 
-      <div className="mb-8 rounded-xl border border-gray-200 bg-white p-6">
+      <div className="rounded-xl border border-gray-200 bg-white p-6">
         <h2 className="mb-4 text-xl font-bold">Add Category</h2>
 
         <form action={createCategory} className="grid gap-4 md:grid-cols-2">
@@ -88,7 +58,7 @@ export default async function AddCategoryPage() {
         </form>
       </div>
 
-      <table className="w-full text-left border border-gray-200 rounded-xl bg-white">
+      <table className="w-full rounded-xl border border-gray-200 bg-white text-left">
         <thead className="bg-gray-50 text-sm text-gray-600">
           <tr>
             <th className="px-6 py-4">Name</th>
@@ -100,11 +70,11 @@ export default async function AddCategoryPage() {
           {categories.map((category) => (
             <tr key={category.id} className="text-sm text-gray-700">
               <td className="px-6 py-4">{category.name}</td>
-              <td className="px-6 py-4 break-all">{category.image}</td>
+              <td className="break-all px-6 py-4">{category.image}</td>
             </tr>
           ))}
         </tbody>
       </table>
-    </main>
+    </div>
   );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,6 +2,7 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { getUserByEmail } from "@/app/api/user/get-current-user";
+import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export default async function AdminLayout({
   children,
@@ -24,5 +25,15 @@ export default async function AdminLayout({
     redirect("/");
   }
 
-  return <>{children}</>;
+  return (
+    <main className="mx-auto max-w-7xl px-6 pb-10 pt-28">
+      <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr]">
+        <aside className="self-start">
+          <AdminSidebar />
+        </aside>
+
+        <section>{children}</section>
+      </div>
+    </main>
+  );
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,7 +2,6 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { getUserByEmail } from "@/app/api/user/get-current-user";
-import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export default async function AdminLayout({
   children,
@@ -25,15 +24,5 @@ export default async function AdminLayout({
     redirect("/");
   }
 
-  return (
-    <main className="mx-auto max-w-7xl px-6 pb-10 pt-28">
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr]">
-        <aside className="self-start">
-          <AdminSidebar />
-        </aside>
-
-        <section>{children}</section>
-      </div>
-    </main>
-  );
+  return <main className="mx-auto max-w-7xl px-6 pb-10 pt-28">{children}</main>;
 }

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -2,9 +2,12 @@ import { redirect } from "next/navigation";
 import { getServerSession } from "next-auth";
 import { authOptions } from "@/lib/auth/auth-options";
 import { getUserByEmail } from "@/app/api/user/get-current-user";
-import AdminPanel from "@/components/admin/AdminPanel";
 
-export default async function AdminPage() {
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
   const session = await getServerSession(authOptions);
 
   if (!session?.user?.email) {
@@ -21,9 +24,5 @@ export default async function AdminPage() {
     redirect("/");
   }
 
-  return (
-    <main className="mx-auto max-w-7xl px-6 pb-10 pt-28">
-      <AdminPanel />
-    </main>
-  );
+  return <>{children}</>;
 }

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,20 +1,18 @@
 type AdminHeaderProps = {
   onAddBike: () => void;
   onAddAccessory: () => void;
-  onAddCategory: () => void;
 };
 
 export default function AdminHeader({
   onAddBike,
   onAddAccessory,
-  onAddCategory,
 }: AdminHeaderProps) {
   return (
     <div>
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
       <p className="text-gray-500">Manage bikes and orders</p>
 
-      <div className="mt-4 flex flex-wrap items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         <button
           type="button"
           className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
@@ -37,14 +35,6 @@ export default function AdminHeader({
           className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-sm font-medium text-black transition hover:bg-gray-50"
         >
           Add Accessory
-        </button>
-
-        <button
-          type="button"
-          onClick={onAddCategory}
-          className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-sm font-medium text-black transition hover:bg-gray-50"
-        >
-          Add Category
         </button>
       </div>
     </div>

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,14 +1,52 @@
-export default function AdminHeader() {
+type AdminHeaderProps = {
+  onAddBike: () => void;
+  onAddAccessory: () => void;
+  onAddCategory: () => void;
+};
+
+export default function AdminHeader({
+  onAddBike,
+  onAddAccessory,
+  onAddCategory,
+}: AdminHeaderProps) {
   return (
     <div>
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
       <p className="text-gray-500">Manage bikes and orders</p>
-      <button
-        className="mt-4 px-4 py-2 bg-black text-white rounded hover:bg-gray-800 transition"
-        onClick={() => (window.location.href = "/admin/accessories")}
-      >
-        Go to Accessories
-      </button>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
+          onClick={() => (window.location.href = "/admin/accessories")}
+        >
+          Go to Accessories
+        </button>
+
+        <button
+          type="button"
+          onClick={onAddBike}
+          className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
+        >
+          Add Bike
+        </button>
+
+        <button
+          type="button"
+          onClick={onAddAccessory}
+          className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-sm font-medium text-black transition hover:bg-gray-50"
+        >
+          Add Accessory
+        </button>
+
+        <button
+          type="button"
+          onClick={onAddCategory}
+          className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-sm font-medium text-black transition hover:bg-gray-50"
+        >
+          Add Category
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -5,7 +5,6 @@ import { useRouter } from "next/navigation";
 import AdminHeader from "./AdminHeader";
 import AdminTabs from "./AdminTabs";
 import AdminStats from "./AdminStats";
-import AdminActions from "./AdminActions";
 import AdminSidebar from "./AdminSidebar";
 import BikesTable from "./BikesTable";
 import AddBikeModal from "./AddBikeModal";
@@ -77,7 +76,11 @@ export default function AdminPanel() {
       </aside>
 
       <section className="space-y-6">
-        <AdminHeader />
+        <AdminHeader
+          onAddBike={handleAddBike}
+          onAddAccessory={handleAddAccessory}
+          onAddCategory={handleAddCategory}
+        />
 
         <AdminTabs
           activeTab={activeTab}
@@ -90,12 +93,6 @@ export default function AdminPanel() {
           activeOrders={0}
           inRepair={0}
           totalAccessories={accessories.length}
-        />
-
-        <AdminActions
-          onAddBike={handleAddBike}
-          onAddAccessory={handleAddAccessory}
-          onAddCategory={handleAddCategory}
         />
 
         {activeTab === "bikes" && (

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -6,6 +6,7 @@ import AdminHeader from "./AdminHeader";
 import AdminTabs from "./AdminTabs";
 import AdminStats from "./AdminStats";
 import AdminActions from "./AdminActions";
+import AdminSidebar from "./AdminSidebar";
 import BikesTable from "./BikesTable";
 import AddBikeModal from "./AddBikeModal";
 import { Bike } from "@/types/admin";
@@ -70,37 +71,49 @@ export default function AdminPanel() {
   };
 
   return (
-    <div className="space-y-6">
-      <AdminHeader />
-      <AdminTabs
-        activeTab={activeTab}
-        onChangeTab={setActiveTab}
-        activeOrdersCount={0}
-      />
-      <AdminStats
-        totalBikes={bikes.length}
-        activeOrders={0}
-        inRepair={0}
-        totalAccessories={accessories.length}
-      />
-      <AdminActions
-        onAddBike={handleAddBike}
-        onAddAccessory={handleAddAccessory}
-        onAddCategory={handleAddCategory}
-      />
-      {activeTab === "bikes" && (
-        <BikesTable
-          bikes={bikes}
-          categories={categories}
-          onDeleteSuccess={loadBikes}
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr]">
+      <aside className="self-start">
+        <AdminSidebar />
+      </aside>
+
+      <section className="space-y-6">
+        <AdminHeader />
+
+        <AdminTabs
+          activeTab={activeTab}
+          onChangeTab={setActiveTab}
+          activeOrdersCount={0}
         />
-      )}
+
+        <AdminStats
+          totalBikes={bikes.length}
+          activeOrders={0}
+          inRepair={0}
+          totalAccessories={accessories.length}
+        />
+
+        <AdminActions
+          onAddBike={handleAddBike}
+          onAddAccessory={handleAddAccessory}
+          onAddCategory={handleAddCategory}
+        />
+
+        {activeTab === "bikes" && (
+          <BikesTable
+            bikes={bikes}
+            categories={categories}
+            onDeleteSuccess={loadBikes}
+          />
+        )}
+      </section>
+
       <AddBikeModal
         open={showAddBike}
         onClose={() => setShowAddBike(false)}
         onSuccess={handleAddBikeSuccess}
         categories={categories}
       />
+
       <AddAccessoryModal
         open={showAddAccessory}
         onClose={() => setShowAddAccessory(false)}

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import AdminHeader from "./AdminHeader";
 import AdminTabs from "./AdminTabs";
 import AdminStats from "./AdminStats";
-import AdminSidebar from "./AdminSidebar";
+import AdminActions from "./AdminActions";
 import BikesTable from "./BikesTable";
 import AddBikeModal from "./AddBikeModal";
 import { Bike } from "@/types/admin";
@@ -70,11 +70,7 @@ export default function AdminPanel() {
   };
 
   return (
-    <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr]">
-      <aside className="self-start">
-        <AdminSidebar />
-      </aside>
-
+    <>
       <section className="space-y-6">
         <AdminHeader
           onAddBike={handleAddBike}
@@ -92,6 +88,12 @@ export default function AdminPanel() {
           totalBikes={bikes.length}
           activeOrders={0}
           totalAccessories={accessories.length}
+        />
+
+        <AdminActions
+          onAddBike={handleAddBike}
+          onAddAccessory={handleAddAccessory}
+          onAddCategory={handleAddCategory}
         />
 
         {activeTab === "bikes" && (
@@ -115,6 +117,6 @@ export default function AdminPanel() {
         onClose={() => setShowAddAccessory(false)}
         onSuccess={handleAddAccessorySuccess}
       />
-    </div>
+    </>
   );
 }

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -91,7 +91,6 @@ export default function AdminPanel() {
         <AdminStats
           totalBikes={bikes.length}
           activeOrders={0}
-          inRepair={0}
           totalAccessories={accessories.length}
         />
 

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -2,14 +2,15 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
+
 import AdminHeader from "./AdminHeader";
 import AdminTabs from "./AdminTabs";
 import AdminStats from "./AdminStats";
-import AdminActions from "./AdminActions";
 import BikesTable from "./BikesTable";
 import AddBikeModal from "./AddBikeModal";
-import { Bike } from "@/types/admin";
 import AddAccessoryModal from "./AddAccessoryModal";
+import AdminSidebar from "./AdminSidebar";
+import { Bike } from "@/types/admin";
 import { Category } from "@/types/Category";
 
 export default function AdminPanel() {
@@ -70,12 +71,15 @@ export default function AdminPanel() {
   };
 
   return (
-    <>
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-[210px_1fr] items-start">
+      <div className="self-start">
+        <AdminSidebar />
+      </div>
+
       <section className="space-y-6">
         <AdminHeader
           onAddBike={handleAddBike}
           onAddAccessory={handleAddAccessory}
-          onAddCategory={handleAddCategory}
         />
 
         <AdminTabs
@@ -88,12 +92,6 @@ export default function AdminPanel() {
           totalBikes={bikes.length}
           activeOrders={0}
           totalAccessories={accessories.length}
-        />
-
-        <AdminActions
-          onAddBike={handleAddBike}
-          onAddAccessory={handleAddAccessory}
-          onAddCategory={handleAddCategory}
         />
 
         {activeTab === "bikes" && (
@@ -117,6 +115,6 @@ export default function AdminPanel() {
         onClose={() => setShowAddAccessory(false)}
         onSuccess={handleAddAccessorySuccess}
       />
-    </>
+    </div>
   );
 }

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/admin", label: "Dashboard" },
+  { href: "/admin/accessories", label: "Accessories" },
+  { href: "/admin/categories/new", label: "Add Category" },
+];
+
+export default function AdminSidebar() {
+  const pathname = usePathname();
+
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white p-4 shadow-sm">
+      <nav className="flex flex-col gap-2">
+        {links.map((link) => {
+          const isActive = pathname === link.href;
+
+          return (
+            <Link
+              key={link.href}
+              href={link.href}
+              className={`rounded-lg px-4 py-3 text-sm font-medium transition ${
+                isActive
+                  ? "bg-black text-white"
+                  : "text-gray-700 hover:bg-gray-100"
+              }`}
+            >
+              {link.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/src/components/admin/AdminStats.tsx
+++ b/src/components/admin/AdminStats.tsx
@@ -1,18 +1,16 @@
 type AdminStatsProps = {
   totalBikes: number;
   activeOrders: number;
-  inRepair: number;
   totalAccessories: number;
 };
 
 export default function AdminStats({
   totalBikes,
   activeOrders,
-  inRepair,
   totalAccessories,
 }: AdminStatsProps) {
   return (
-    <section className="grid grid-cols-1 gap-4 md:grid-cols-4">
+    <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
       <div className="rounded-xl border border-gray-200 bg-white p-6">
         <p className="text-sm text-gray-500">Total Bikes</p>
         <h2 className="mt-3 text-4xl font-semibold text-black">{totalBikes}</h2>
@@ -26,13 +24,10 @@ export default function AdminStats({
       </div>
 
       <div className="rounded-xl border border-gray-200 bg-white p-6">
-        <p className="text-sm text-gray-500">In Repair</p>
-        <h2 className="mt-3 text-4xl font-semibold text-black">{inRepair}</h2>
-      </div>
-
-      <div className="rounded-xl border border-gray-200 bg-white p-6">
         <p className="text-sm text-gray-500">Total Accessories</p>
-        <h2 className="mt-3 text-4xl font-semibold text-black">{totalAccessories}</h2>
+        <h2 className="mt-3 text-4xl font-semibold text-black">
+          {totalAccessories}
+        </h2>
       </div>
     </section>
   );


### PR DESCRIPTION
## What was done

Refactored the admin section to use a shared layout with a persistent sidebar.

### Changes
- introduced a shared layout for `/admin`
- moved sidebar rendering to the admin layout
- updated admin pages to work inside the shared layout
- removed duplicated UI elements from the dashboard
- partially cleaned up admin UI structure

## Current state (WIP)

This is a work in progress PR.

The main layout refactor is implemented, but some UI details are not finalized yet:
- action buttons positioning is still unclear
- spacing/alignment may need adjustments
- final UX decisions are pending clarification

## Result (current)
Navigation between admin pages works with a persistent sidebar:
- `/admin`
- `/admin/accessories`
- `/admin/categories/new`

Sidebar remains visible, and content updates on the right.

## What needs to be done
- clarify expected positioning of action buttons
- finalize spacing and alignment
- polish UI consistency across admin pages

## How to test
1. Open `/admin`
2. Navigate to `Accessories`
3. Navigate to `Add Category`
4. Verify sidebar stays visible across pages
5. Check dashboard UI for duplicated elements

## Notes
Pushing this PR in its current state to share progress and get feedback on UI/UX before finalizing.