### PR TITLE
fix(admin): validate accessory price input (#128)

### DIFF
--- a/src/components/admin/AddAccessoryModal.tsx
+++ b/src/components/admin/AddAccessoryModal.tsx
@@ -67,6 +67,8 @@ export default function AddAccessoryModal({
           onChange={handleChange}
           placeholder="Price per day"
           type="number"
+          min="0"
+          step="0.01"
           className="mb-2 w-full border p-2 rounded"
           required
         />


### PR DESCRIPTION
## What
- added validation for accessory price input in AddAccessoryModal
- set `min="0"` to prevent negative values
- added `step="0.01"` to support decimal prices

## Why
Previously accessory price field allowed negative values, which is invalid.

## Check
- open `/admin`
- click "Add Accessory"
- try to enter negative price (e.g. -10)
- browser should block submission
- enter valid decimal price → form should submit