### PR TITLE
fix(admin): implement delete confirmation modal and fix bike delete action (#129)

### DIFF
--- a/src/components/admin/BikesTable.tsx
+++ b/src/components/admin/BikesTable.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import EmptyState from "@/components/admin/EmptyState";
 import EditBikeModal from "@/components/admin/EditBikeModal";
+import DeleteConfirmationModal from "@/components/admin/DeleteConfirmationModal";
 import type { Bike } from "@/types/admin";
 import type { Category } from "@/types/Category";
 import deleteBike from "@/app/api/actions-bike/delete-bike";
@@ -20,6 +21,9 @@ export default function BikesTable({
 }: BikesTableProps) {
   const [showEditModal, setShowEditModal] = useState(false);
   const [selectedBikeId, setSelectedBikeId] = useState<string | null>(null);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [bikeToDelete, setBikeToDelete] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleEditBike = (id: string) => {
     setSelectedBikeId(id);
@@ -30,17 +34,31 @@ export default function BikesTable({
     alert(`Repair bike: ${id}`);
   };
 
-  const handleDeleteBike = async (id: string) => {
-    const confirmed = confirm("Are you sure you want to delete this bike?");
-    if (!confirmed) return;
+  const handleDeleteButtonClick = (id: string) => {
+    setBikeToDelete(id);
+    setShowDeleteModal(true);
+  };
 
+  const handleConfirmDelete = async () => {
+    if (!bikeToDelete) return;
+
+    setIsDeleting(true);
     try {
-      await deleteBike(id);
+      await deleteBike(bikeToDelete);
+      setShowDeleteModal(false);
+      setBikeToDelete(null);
       await onDeleteSuccess();
     } catch (error) {
       console.error("Delete failed:", error);
       alert("Failed to delete bike");
+      setIsDeleting(false);
     }
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteModal(false);
+    setBikeToDelete(null);
+    setIsDeleting(false);
   };
 
   const handleEditSuccess = async () => {
@@ -94,13 +112,16 @@ export default function BikesTable({
 
                 <td className="px-6 py-4">
                   <div className="flex items-center gap-3 text-base">
-                    <button type="button" onClick={() => handleEditBike(bike.id)}>
+                    <button
+                      type="button"
+                      onClick={() => handleEditBike(bike.id)}
+                    >
                       ✏️
                     </button>
 
                     <button
                       type="button"
-                      onClick={() => handleDeleteBike(bike.id)}
+                      onClick={() => handleDeleteButtonClick(bike.id)}
                     >
                       🗑️
                     </button>
@@ -121,6 +142,15 @@ export default function BikesTable({
         }}
         onSuccess={handleEditSuccess}
         categories={categories}
+      />
+
+      <DeleteConfirmationModal
+        open={showDeleteModal}
+        title="Delete Bike"
+        description="Are you sure you want to delete this bike? This action cannot be undone."
+        isLoading={isDeleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
       />
     </>
   );

--- a/src/components/admin/DeleteConfirmationModal.tsx
+++ b/src/components/admin/DeleteConfirmationModal.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+type DeleteConfirmationModalProps = {
+  open: boolean;
+  title: string;
+  description: string;
+  isLoading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+};
+
+export default function DeleteConfirmationModal({
+  open,
+  title,
+  description,
+  isLoading = false,
+  onConfirm,
+  onCancel,
+}: DeleteConfirmationModalProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-40">
+      <div className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md">
+        <h2 className="text-xl font-bold mb-2 text-gray-900">{title}</h2>
+        <p className="text-gray-600 mb-6">{description}</p>
+
+        <div className="flex gap-3 justify-end">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 rounded border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="px-4 py-2 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          >
+            {isLoading ? "Deleting..." : "Delete"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What
- replaced browser confirm with a dedicated delete confirmation modal
- fixed bike delete action flow in admin panel
- added proper modal state handling for delete confirmation

## Why
Previously action confirmation appeared, but no proper admin-side delete flow was implemented.

## Check
- open `/admin`
- click delete icon on any bike
- custom confirmation modal should open
- confirm deletion
- bike should be removed from the list