### PR TITLE
feat(admin): add dashboard layout with sidebar (#142)

### DIFF
--- a/src/components/admin/BikesTable.tsx
+++ b/src/components/admin/BikesTable.tsx
@@ -76,7 +76,7 @@ export default function BikesTable({
 
   return (
     <>
-      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+      <div className="overflow-y-auto max-h-80 rounded-xl border border-gray-200 bg-white">
         <table className="w-full text-left">
           <thead className="bg-gray-50 text-sm text-gray-600">
             <tr>


### PR DESCRIPTION
## What
- added admin dashboard layout with left sidebar
- moved admin content into right content area
- aligned structure with user profile layout approach

## Why
Admin dashboard needed a clearer layout structure with persistent sidebar navigation.

## Check
- open `/admin`
- sidebar should be visible on the left
- content should be shown on the right
- page should not overlap with header