### PR TITLE
fix(admin-147): validate Add Bike form and block unsupported symbols

### DIFF
--- a/src/app/api/actions-bike/create-bike.ts
+++ b/src/app/api/actions-bike/create-bike.ts
@@ -17,6 +17,21 @@ export async function createBike(formData: FormData) {
   const image = formData.get("image") as string;
   const bikeCategoryId = formData.get("bike_category_id") as string;
 
+  const validateTextField = (name: string, value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+    const re = /^[a-zA-Z0-9\s.,'"()\-]+$/;
+    if (!re.test(trimmed)) {
+      throw new Error(`${name} contains unsupported special characters`);
+    }
+  };
+
+  validateTextField("Brand", brand);
+  validateTextField("Model", model);
+  validateTextField("Description", description);
+
   const pricePerDay = Number(pricePerDayRaw);
 
   if (Number.isNaN(pricePerDay)) {

--- a/src/components/admin/AddBikeModal.tsx
+++ b/src/components/admin/AddBikeModal.tsx
@@ -31,12 +31,39 @@ export default function AddBikeModal({
     e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
   ) => {
     setForm({ ...form, [e.target.name]: e.target.value });
+    if (error) {
+      setError("");
+    }
+  };
+
+  const isValidText = (value: string) => {
+    if (!value.trim()) return true;
+    const re = /^[a-zA-Z0-9\s.,'"()\-]+$/;
+    return re.test(value.trim());
   };
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setLoading(true);
     setError("");
+
+    if (!isValidText(form.brand)) {
+      setLoading(false);
+      setError("Brand contains unsupported special characters.");
+      return;
+    }
+
+    if (!isValidText(form.model)) {
+      setLoading(false);
+      setError("Model contains unsupported special characters.");
+      return;
+    }
+
+    if (form.description && !isValidText(form.description)) {
+      setLoading(false);
+      setError("Description contains unsupported special characters.");
+      return;
+    }
 
     const price = Number(form.price_per_day);
 


### PR DESCRIPTION
## Summary
Fixes bug #147 where the Add Bike form allowed unsupported special characters in text fields.

## Problem
The form on the Admin page accepted invalid special characters in:
- brand
- model
- description

This allowed incorrect data to be submitted.

## Solution

### Client-side validation (`AddBikeModal.tsx`)
- Added `isValidText` function with allowed characters:
  - A-Z, a-z, 0-9, space, `. , ' " ( ) -`
- Prevent form submission if validation fails
- Show error message for invalid input
- Reset error message on input change
- Validate:
  - `brand` (required)
  - `model` (required)
  - `description` (optional)

### Server-side validation (`create-bike.ts`)
- Added `validateTextField(name, value)` helper
- Applied validation to:
  - `brand`
  - `model`
  - `description`
- Throws error if unsupported characters are detected

## Result
- Form rejects invalid input consistently
- User receives clear error messages
- Submission is blocked until data is valid
- Dual-layer protection implemented (client + server)

## How to test
1. Open Admin → Add Bike
2. Enter invalid characters (e.g. `!!!`, `###`)
3. Verify:
   - error message is shown
   - form is not submitted
4. Enter valid data → form submits successfully

Closes #147