### PR TITLE
Fix: resolve Image component error and update footer year

### DIFF
--- a/src/components/footer/index.tsx
+++ b/src/components/footer/index.tsx
@@ -130,7 +130,7 @@ export default function Footer() {
       </section>
 
       <section className="mt-8 pt-6 border-t border-gray-700 text-center">
-        © 2025 BlablaBike. All rights reserved.
+        © 2026 BlablaBike. All rights reserved.
       </section>
     </footer>
   );

--- a/src/components/sign-in-sign-out/index.tsx
+++ b/src/components/sign-in-sign-out/index.tsx
@@ -26,7 +26,7 @@ export default function SignInSignOut() {
             className="relative group flex items-center outline-none cursor-help"
             tabIndex={0}
           >
-            <div className="relative w-[26px] h-[26px] rounded-full overflow-hidden border border-black/10 bg-zinc-200">
+            <div className="relative w-6.5 h-6.5 rounded-full overflow-hidden border border-black/10 bg-zinc-200">
               <Image
                 src={avatarSrc}
                 alt={session.user?.name || "User"}
@@ -40,7 +40,8 @@ export default function SignInSignOut() {
               <Image
                 src={DEFAULT_AVATAR}
                 alt="fallback"
-                className="absolute inset-0 w-full h-full object-cover"
+                fill
+                className="object-cover"
               />
             </div>
 


### PR DESCRIPTION
## Changes
- Fixed Next.js Image runtime error (missing width/height)
- Updated fallback avatar to use `fill` prop correctly
- Updated footer year from 2025 to current year

## Problem
- Application crashed due to incorrect usage of `next/image`
- Footer contained outdated year (2025)

## How to test
1. Run the app: npm run dev
2. Open in browser
3. Check that:
   - no runtime errors
   - avatar displays correctly
   - footer shows updated year