### PR TITLE
refactor(admin-175): clean up admin dashboard and move Add Accessory to Accessories

### DIFF
--- a/src/app/admin/accessories/page.tsx
+++ b/src/app/admin/accessories/page.tsx
@@ -68,8 +68,14 @@ export default function AdminAccessoriesPage() {
         </div>
 
         <div>
-          <div className="mb-6 flex items-center justify-between gap-4">
+          <div className="mb-6">
             <h1 className="text-3xl font-bold">Accessories</h1>
+          </div>
+
+          <div className="mb-6 flex flex-col items-start gap-4">
+            <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
+              Total Accessories: {accessories.length}
+            </div>
 
             <button
               type="button"
@@ -78,12 +84,6 @@ export default function AdminAccessoriesPage() {
             >
               Add Accessory
             </button>
-          </div>
-
-          <div className="mb-6 flex gap-6">
-            <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
-              Total Accessories: {accessories.length}
-            </div>
           </div>
           <table className="w-full text-left border border-gray-200 rounded-xl bg-white">
             <thead className="bg-gray-50 text-sm text-gray-600">

--- a/src/app/admin/accessories/page.tsx
+++ b/src/app/admin/accessories/page.tsx
@@ -2,20 +2,28 @@
 import { useEffect, useState } from "react";
 import React from "react";
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import AddAccessoryModal from "@/components/admin/AddAccessoryModal";
 
 export default function AdminAccessoriesPage() {
   const [accessories, setAccessories] = useState([]);
+  const [showAddAccessory, setShowAddAccessory] = useState(false);
   const [editModalOpen, setEditModalOpen] = useState(false);
   const [editForm, setEditForm] = useState<any>({});
   const [editId, setEditId] = useState<string | null>(null);
-  const handleDeleteAccessory = async (id: string) => {
-    await fetch(`/api/actions-accessory/delete-accessory?id=${id}`, {
-      method: "POST",
-    });
+
+  const loadAccessories = () => {
     fetch("/api/actions-accessory/read-all-accessories")
       .then((res) => res.json())
       .then((accs) => setAccessories(accs));
   };
+
+  const handleDeleteAccessory = async (id: string) => {
+    await fetch(`/api/actions-accessory/delete-accessory?id=${id}`, {
+      method: "POST",
+    });
+    loadAccessories();
+  };
+
   const handleEditAccessory = (acc: any) => {
     setEditForm({
       name: acc.name || "",
@@ -40,14 +48,16 @@ export default function AdminAccessoriesPage() {
       body: formData,
     });
     setEditModalOpen(false);
-    fetch("/api/actions-accessory/read-all-accessories")
-      .then((res) => res.json())
-      .then((accs) => setAccessories(accs));
+    loadAccessories();
   };
+
+  const handleAddAccessorySuccess = () => {
+    setShowAddAccessory(false);
+    loadAccessories();
+  };
+
   useEffect(() => {
-    fetch("/api/actions-accessory/read-all-accessories")
-      .then((res) => res.json())
-      .then((accs) => setAccessories(accs));
+    loadAccessories();
   }, []);
 
   return (
@@ -58,9 +68,18 @@ export default function AdminAccessoriesPage() {
         </div>
 
         <div>
-          <div className="flex items-center mb-6">
+          <div className="mb-6 flex items-center justify-between gap-4">
             <h1 className="text-3xl font-bold">Accessories</h1>
+
+            <button
+              type="button"
+              onClick={() => setShowAddAccessory(true)}
+              className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
+            >
+              Add Accessory
+            </button>
           </div>
+
           <div className="mb-6 flex gap-6">
             <div className="bg-gray-100 rounded-xl px-6 py-4 text-lg font-semibold">
               Total Accessories: {accessories.length}
@@ -138,6 +157,12 @@ export default function AdminAccessoriesPage() {
               </form>
             </div>
           )}
+
+          <AddAccessoryModal
+            open={showAddAccessory}
+            onClose={() => setShowAddAccessory(false)}
+            onSuccess={handleAddAccessorySuccess}
+          />
         </div>
       </div>
     </div>

--- a/src/components/admin/AdminHeader.tsx
+++ b/src/components/admin/AdminHeader.tsx
@@ -1,12 +1,8 @@
 type AdminHeaderProps = {
   onAddBike: () => void;
-  onAddAccessory: () => void;
 };
 
-export default function AdminHeader({
-  onAddBike,
-  onAddAccessory,
-}: AdminHeaderProps) {
+export default function AdminHeader({ onAddBike }: AdminHeaderProps) {
   return (
     <div>
       <h1 className="text-3xl font-bold">Admin Dashboard</h1>
@@ -15,26 +11,10 @@ export default function AdminHeader({
       <div className="flex flex-wrap items-center gap-3">
         <button
           type="button"
-          className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
-          onClick={() => (window.location.href = "/admin/accessories")}
-        >
-          Go to Accessories
-        </button>
-
-        <button
-          type="button"
           onClick={onAddBike}
           className="rounded-lg bg-black px-5 py-3 text-sm font-medium text-white transition hover:opacity-90"
         >
           Add Bike
-        </button>
-
-        <button
-          type="button"
-          onClick={onAddAccessory}
-          className="rounded-lg border border-gray-300 bg-white px-5 py-3 text-sm font-medium text-black transition hover:bg-gray-50"
-        >
-          Add Accessory
         </button>
       </div>
     </div>

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -1,26 +1,20 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { useRouter } from "next/navigation";
 
 import AdminHeader from "./AdminHeader";
-import AdminTabs from "./AdminTabs";
 import AdminStats from "./AdminStats";
 import BikesTable from "./BikesTable";
 import AddBikeModal from "./AddBikeModal";
-import AddAccessoryModal from "./AddAccessoryModal";
 import AdminSidebar from "./AdminSidebar";
 import { Bike } from "@/types/admin";
 import { Category } from "@/types/Category";
 
 export default function AdminPanel() {
-  const [showAddAccessory, setShowAddAccessory] = useState(false);
-  const [activeTab, setActiveTab] = useState<"bikes" | "orders">("bikes");
   const [bikes, setBikes] = useState<Bike[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [accessories, setAccessories] = useState([]);
   const [showAddBike, setShowAddBike] = useState(false);
-  const router = useRouter();
 
   const loadBikes = async () => {
     const res = await fetch("/api/bikes");
@@ -50,19 +44,6 @@ export default function AdminPanel() {
       .then((accs) => setAccessories(accs));
   }, []);
 
-  const handleAddAccessory = () => setShowAddAccessory(true);
-
-  const handleAddCategory = () => {
-    router.push("/admin/categories/new");
-  };
-
-  const handleAddAccessorySuccess = () => {
-    setShowAddAccessory(false);
-    fetch("/api/actions-accessory/read-all-accessories")
-      .then((res) => res.json())
-      .then((accs) => setAccessories(accs));
-  };
-
   const handleAddBike = () => setShowAddBike(true);
 
   const handleAddBikeSuccess = async () => {
@@ -77,16 +58,7 @@ export default function AdminPanel() {
       </div>
 
       <section className="space-y-6">
-        <AdminHeader
-          onAddBike={handleAddBike}
-          onAddAccessory={handleAddAccessory}
-        />
-
-        <AdminTabs
-          activeTab={activeTab}
-          onChangeTab={setActiveTab}
-          activeOrdersCount={0}
-        />
+        <AdminHeader onAddBike={handleAddBike} />
 
         <AdminStats
           totalBikes={bikes.length}
@@ -94,13 +66,11 @@ export default function AdminPanel() {
           totalAccessories={accessories.length}
         />
 
-        {activeTab === "bikes" && (
-          <BikesTable
-            bikes={bikes}
-            categories={categories}
-            onDeleteSuccess={loadBikes}
-          />
-        )}
+        <BikesTable
+          bikes={bikes}
+          categories={categories}
+          onDeleteSuccess={loadBikes}
+        />
       </section>
 
       <AddBikeModal
@@ -108,12 +78,6 @@ export default function AdminPanel() {
         onClose={() => setShowAddBike(false)}
         onSuccess={handleAddBikeSuccess}
         categories={categories}
-      />
-
-      <AddAccessoryModal
-        open={showAddAccessory}
-        onClose={() => setShowAddAccessory(false)}
-        onSuccess={handleAddAccessorySuccess}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Refactor Admin Panel by removing redundant actions from the dashboard and relocating Add Accessory to the Accessories section.

## Changes
- removed `Go to Accessories` button from admin dashboard
- removed `Add Accessory` button from admin header
- removed `All Bikes` and `Active Orders` tabs
- moved `Add Accessory` button to Accessories page
- adjusted button position (under "Total Accessories" block)
- kept modal-based accessory creation
- ensured accessories list updates after adding a new item

## Result
- cleaner admin dashboard
- reduced visual clutter
- more intuitive placement of accessory actions

Part of #174  
Closes #175