### PR TITLE
fix(admin-184): handle duplicate category error without crashing page

### DIFF
--- a/src/app/admin/categories/new/page.tsx
+++ b/src/app/admin/categories/new/page.tsx
@@ -1,5 +1,5 @@
 import getAllCategories from "@/app/api/actions-category/read-all-categories";
-import createCategory from "@/app/api/actions-category/create-category";
+import AddCategoryForm from "@/components/admin/AddCategoryForm";
 import AdminSidebar from "@/components/admin/AdminSidebar";
 
 export default async function AddCategoryPage() {
@@ -26,42 +26,7 @@ export default async function AddCategoryPage() {
         <div className="rounded-xl border border-gray-200 bg-white p-6">
           <h2 className="mb-4 text-xl font-bold">Add Category</h2>
 
-          <form action={createCategory} className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700">
-                Name
-              </label>
-              <input
-                name="name"
-                type="text"
-                placeholder="Category name"
-                className="w-full rounded border p-3"
-                required
-              />
-            </div>
-
-            <div>
-              <label className="mb-2 block text-sm font-medium text-gray-700">
-                Image URL
-              </label>
-              <input
-                name="image"
-                type="text"
-                placeholder="https://example.com/category.jpg"
-                className="w-full rounded border p-3"
-                required
-              />
-            </div>
-
-            <div className="md:col-span-2">
-              <button
-                type="submit"
-                className="rounded bg-black px-5 py-3 text-white"
-              >
-                Create Category
-              </button>
-            </div>
-          </form>
+          <AddCategoryForm />
         </div>
 
         <table className="w-full rounded-xl border border-gray-200 bg-white text-left">

--- a/src/app/api/actions-category/create-category.ts
+++ b/src/app/api/actions-category/create-category.ts
@@ -6,16 +6,97 @@ import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { redirect } from "next/navigation";
 
-export default async function createCategory(formData: FormData) {
+type CategoryFormValues = {
+  name: string;
+  image: string;
+};
+
+export type CreateCategoryState = {
+  error: string | null;
+  values: CategoryFormValues;
+};
+
+function getCategoryFormValues(formData: FormData): CategoryFormValues {
+  return {
+    name: String(formData.get("name") ?? "").trim(),
+    image: String(formData.get("image") ?? "").trim(),
+  };
+}
+
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+
+  if ("cause" in error) {
+    return getErrorCode(error.cause);
+  }
+
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? "");
+}
+
+function isUniqueConstraintError(error: unknown) {
+  const errorCode = getErrorCode(error);
+
+  if (errorCode === "23505") {
+    return true;
+  }
+
+  const errorMessage = getErrorMessage(error).toLowerCase();
+
+  return (
+    errorMessage.includes("duplicate key") ||
+    errorMessage.includes("unique constraint")
+  );
+}
+
+export async function createCategoryRecord(values: CategoryFormValues) {
   await requireAdmin();
 
-  const name = formData.get("name") as string;
-  const image = formData.get("image") as string;
-
-  await db.insert(categories).values({ name, image });
+  await db.insert(categories).values(values);
 
   revalidatePath("/admin");
   revalidatePath("/admin/categories/new");
+}
+
+export async function createCategoryAction(
+  _prevState: CreateCategoryState,
+  formData: FormData,
+): Promise<CreateCategoryState> {
+  const values = getCategoryFormValues(formData);
+
+  try {
+    await createCategoryRecord(values);
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return {
+        error: "Category already exists",
+        values,
+      };
+    }
+
+    throw error;
+  }
+
+  redirect("/admin/categories/new");
+}
+
+export default async function createCategory(formData: FormData) {
+  const values = getCategoryFormValues(formData);
+
+  await createCategoryRecord(values);
 
   redirect("/admin/categories/new");
 }

--- a/src/app/api/actions-category/routes.ts
+++ b/src/app/api/actions-category/routes.ts
@@ -1,10 +1,48 @@
 import { NextRequest, NextResponse } from "next/server";
-import createCategory from "./create-category"; 
+import { createCategoryRecord } from "./create-category";
 import deleteCategory from "./delete-category";
 import getAllCategories from "./read-all-categories";
 import getCategoryById from "./read-id-category";
 import updateCategory from "./update-category";
 
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+
+  if ("cause" in error) {
+    return getErrorCode(error.cause);
+  }
+
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? "");
+}
+
+function isUniqueConstraintError(error: unknown) {
+  const errorCode = getErrorCode(error);
+
+  if (errorCode === "23505") {
+    return true;
+  }
+
+  const errorMessage = getErrorMessage(error).toLowerCase();
+
+  return (
+    errorMessage.includes("duplicate key") ||
+    errorMessage.includes("unique constraint")
+  );
+}
 
 export async function GET(req: NextRequest) {
   try {
@@ -13,7 +51,9 @@ export async function GET(req: NextRequest) {
 
     if (id) {
       const category = await getCategoryById(id);
-      return category ? NextResponse.json(category) : NextResponse.json({ error: "Not found" }, { status: 404 });
+      return category
+        ? NextResponse.json(category)
+        : NextResponse.json({ error: "Not found" }, { status: 404 });
     }
 
     const data = await getAllCategories();
@@ -23,20 +63,26 @@ export async function GET(req: NextRequest) {
   }
 }
 
-
 export async function POST(req: NextRequest) {
   try {
     const body = await req.json();
-    const formData = new FormData();
-    Object.entries(body).forEach(([key, value]) => formData.append(key, String(value)));
-    
-    await createCategory(formData);
+    await createCategoryRecord({
+      name: String(body.name ?? "").trim(),
+      image: String(body.image ?? "").trim(),
+    });
+
     return NextResponse.json({ message: "Category created" }, { status: 201 });
   } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return NextResponse.json(
+        { error: "Category already exists" },
+        { status: 409 },
+      );
+    }
+
     return NextResponse.json({ error: "Creation failed" }, { status: 400 });
   }
 }
-
 
 export async function PATCH(req: NextRequest) {
   try {
@@ -46,7 +92,9 @@ export async function PATCH(req: NextRequest) {
 
     const body = await req.json();
     const formData = new FormData();
-    Object.entries(body).forEach(([key, value]) => formData.append(key, String(value)));
+    Object.entries(body).forEach(([key, value]) =>
+      formData.append(key, String(value)),
+    );
 
     await updateCategory(id, formData);
     return NextResponse.json({ message: "Category updated" });
@@ -54,7 +102,6 @@ export async function PATCH(req: NextRequest) {
     return NextResponse.json({ error: "Update failed" }, { status: 400 });
   }
 }
-
 
 export async function DELETE(req: NextRequest) {
   try {

--- a/src/components/admin/AddCategoryForm.tsx
+++ b/src/components/admin/AddCategoryForm.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import {
+  createCategoryAction,
+  type CreateCategoryState,
+} from "@/app/api/actions-category/create-category";
+import { useActionState } from "react";
+
+const initialState: CreateCategoryState = {
+  error: null,
+  values: {
+    name: "",
+    image: "",
+  },
+};
+
+export default function AddCategoryForm() {
+  const [state, formAction] = useActionState(
+    createCategoryAction,
+    initialState,
+  );
+
+  return (
+    <form action={formAction} className="grid gap-4 md:grid-cols-2">
+      <div>
+        <label className="mb-2 block text-sm font-medium text-gray-700">
+          Name
+        </label>
+        <input
+          name="name"
+          type="text"
+          placeholder="Category name"
+          className="w-full rounded border p-3"
+          defaultValue={state.values.name}
+          required
+        />
+      </div>
+
+      <div>
+        <label className="mb-2 block text-sm font-medium text-gray-700">
+          Image URL
+        </label>
+        <input
+          name="image"
+          type="text"
+          placeholder="https://example.com/category.jpg"
+          className="w-full rounded border p-3"
+          defaultValue={state.values.image}
+          required
+        />
+      </div>
+
+      <div className="md:col-span-2 min-h-6">
+        {state.error && (
+          <p className="text-sm text-red-600" role="alert">
+            {state.error}
+          </p>
+        )}
+      </div>
+
+      <div className="md:col-span-2">
+        <button type="submit" className="rounded bg-black px-5 py-3 text-white">
+          Create Category
+        </button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
## Summary
Fix bug where creating an already existing category caused a server error page instead of a controlled user-facing message.

## Problem
When attempting to create a category with a duplicate name:
- Postgres threw a unique constraint error (23505)
- Drizzle wrapped this error into `DrizzleQueryError`
- the error was not properly detected
- the application crashed and showed a server error page

## Solution

### Server-side (create-category.ts, routes.ts)
- added robust duplicate error detection:
  - check `error.code`
  - check `error.cause.code` (for Drizzle wrapped errors)
  - fallback check via error message (`duplicate key`, `unique constraint`)
- introduced controlled handling for duplicate category creation
- prevented unhandled exceptions from reaching the runtime

### Action layer
- implemented `createCategoryAction`
- return structured form state instead of throwing
- preserve user input on error

### Client-side (AddCategoryForm.tsx)
- migrated form to `useActionState`
- display validation error ("Category already exists")
- keep user on the same page

### Page integration
- updated `page.tsx` to use the new form component
- no changes to surrounding admin logic

## Result
- application no longer crashes on duplicate category
- user stays on Add Category page
- clear error message is shown
- successful creation flow remains unchanged

## Technical note
Drizzle wraps Postgres errors inside `DrizzleQueryError`, placing the original error code (23505) in `error.cause.code`. This PR ensures both direct and wrapped errors are handled.

Part of #174  
Closes #184