### PR TITLE
fix(admin-188): add delete action for categories in admin

### DIFF
--- a/src/app/admin/categories/new/page.tsx
+++ b/src/app/admin/categories/new/page.tsx
@@ -1,6 +1,7 @@
 import getAllCategories from "@/app/api/actions-category/read-all-categories";
 import AddCategoryForm from "@/components/admin/AddCategoryForm";
 import AdminSidebar from "@/components/admin/AdminSidebar";
+import CategoriesTable from "@/components/admin/CategoriesTable";
 
 export default async function AddCategoryPage() {
   const categories = await getAllCategories();
@@ -17,35 +18,13 @@ export default async function AddCategoryPage() {
           <p className="text-gray-500">Create and review bike categories</p>
         </div>
 
-        <div className="flex gap-6">
-          <div className="rounded-xl bg-gray-100 px-6 py-4 text-lg font-semibold">
-            Total Categories: {categories.length}
-          </div>
-        </div>
-
         <div className="rounded-xl border border-gray-200 bg-white p-6">
           <h2 className="mb-4 text-xl font-bold">Add Category</h2>
 
           <AddCategoryForm />
         </div>
 
-        <table className="w-full rounded-xl border border-gray-200 bg-white text-left">
-          <thead className="bg-gray-50 text-sm text-gray-600">
-            <tr>
-              <th className="px-6 py-4">Name</th>
-              <th className="px-6 py-4">Image</th>
-            </tr>
-          </thead>
-
-          <tbody className="divide-y divide-gray-200">
-            {categories.map((category) => (
-              <tr key={category.id} className="text-sm text-gray-700">
-                <td className="px-6 py-4">{category.name}</td>
-                <td className="break-all px-6 py-4">{category.image}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <CategoriesTable initialCategories={categories} />
       </div>
     </div>
   );

--- a/src/app/api/actions-category/delete-category.ts
+++ b/src/app/api/actions-category/delete-category.ts
@@ -6,12 +6,62 @@ import { eq } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+
+  if ("cause" in error) {
+    return getErrorCode(error.cause);
+  }
+
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  return String(error ?? "");
+}
+
+function isForeignKeyConstraintError(error: unknown) {
+  const errorCode = getErrorCode(error);
+
+  if (errorCode === "23503") {
+    return true;
+  }
+
+  const message = getErrorMessage(error).toLowerCase();
+
+  return (
+    message.includes("foreign key") ||
+    message.includes("violates foreign key constraint")
+  );
+}
+
 export default async function deleteCategory(id: string) {
   await requireAdmin();
 
   if (!id) return;
 
-  await db.delete(categories).where(eq(categories.id, id));
+  try {
+    await db.delete(categories).where(eq(categories.id, id));
+  } catch (error) {
+    if (isForeignKeyConstraintError(error)) {
+      throw new Error(
+        "Cannot delete category because it is used by existing bikes.",
+      );
+    }
+
+    throw new Error("Failed to delete category");
+  }
 
   revalidatePath("/admin");
+  revalidatePath("/admin/categories/new");
 }

--- a/src/app/api/actions-category/routes.ts
+++ b/src/app/api/actions-category/routes.ts
@@ -112,6 +112,9 @@ export async function DELETE(req: NextRequest) {
     await deleteCategory(id);
     return NextResponse.json({ message: "Category deleted" });
   } catch (error) {
-    return NextResponse.json({ error: "Delete failed" }, { status: 400 });
+    const errorMessage =
+      error instanceof Error ? error.message : "Delete failed";
+
+    return NextResponse.json({ error: errorMessage }, { status: 400 });
   }
 }

--- a/src/components/admin/CategoriesTable.tsx
+++ b/src/components/admin/CategoriesTable.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Category } from "@/types/Category";
+import deleteCategory from "@/app/api/actions-category/delete-category";
+import DeleteConfirmationModal from "@/components/admin/DeleteConfirmationModal";
+
+type CategoriesTableProps = {
+  initialCategories: Category[];
+};
+
+export default function CategoriesTable({
+  initialCategories,
+}: CategoriesTableProps) {
+  const [categories, setCategories] = useState<Category[]>(initialCategories);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(
+    null,
+  );
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+
+  const hasCategories = categories.length > 0;
+  const totalCategories = useMemo(() => categories.length, [categories]);
+
+  const handleDeleteButtonClick = (category: Category) => {
+    setCategoryToDelete(category);
+    setDeleteError(null);
+    setShowDeleteModal(true);
+  };
+
+  const handleCancelDelete = () => {
+    setShowDeleteModal(false);
+    setCategoryToDelete(null);
+    setDeleteError(null);
+    setIsDeleting(false);
+  };
+
+  const handleConfirmDelete = async () => {
+    if (!categoryToDelete) {
+      return;
+    }
+
+    setIsDeleting(true);
+    setDeleteError(null);
+
+    try {
+      await deleteCategory(categoryToDelete.id);
+      setCategories((prev) =>
+        prev.filter((item) => item.id !== categoryToDelete.id),
+      );
+      setShowDeleteModal(false);
+      setCategoryToDelete(null);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to delete category";
+      setDeleteError(message);
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <div className="flex gap-6">
+        <div className="rounded-xl bg-gray-100 px-6 py-4 text-lg font-semibold">
+          Total Categories: {totalCategories}
+        </div>
+      </div>
+
+      {deleteError && (
+        <p className="text-sm text-red-600" role="alert">
+          {deleteError}
+        </p>
+      )}
+
+      <table className="w-full rounded-xl border border-gray-200 bg-white text-left">
+        <thead className="bg-gray-50 text-sm text-gray-600">
+          <tr>
+            <th className="px-6 py-4">Name</th>
+            <th className="px-6 py-4">Image</th>
+            <th className="px-6 py-4">Actions</th>
+          </tr>
+        </thead>
+
+        <tbody className="divide-y divide-gray-200">
+          {hasCategories ? (
+            categories.map((category) => (
+              <tr key={category.id} className="text-sm text-gray-700">
+                <td className="px-6 py-4">{category.name}</td>
+                <td className="break-all px-6 py-4">{category.image}</td>
+                <td className="px-6 py-4">
+                  <button
+                    type="button"
+                    className="px-3 py-1.5 text-red-700 hover:bg-red-50"
+                    onClick={() => handleDeleteButtonClick(category)}
+                    aria-label={`Delete category ${category.name}`}
+                  >
+                    🗑️
+                  </button>
+                </td>
+              </tr>
+            ))
+          ) : (
+            <tr className="text-sm text-gray-500">
+              <td className="px-6 py-4" colSpan={3}>
+                No categories found.
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+
+      <DeleteConfirmationModal
+        open={showDeleteModal}
+        title="Delete Category"
+        description={
+          categoryToDelete
+            ? `Are you sure you want to delete \"${categoryToDelete.name}\"? This action cannot be undone.`
+            : "Are you sure you want to delete this category?"
+        }
+        isLoading={isDeleting}
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+      />
+    </>
+  );
+}

--- a/src/components/admin/CategoriesTable.tsx
+++ b/src/components/admin/CategoriesTable.tsx
@@ -1,20 +1,26 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { Category } from "@/types/Category";
 import deleteCategory from "@/app/api/actions-category/delete-category";
 import DeleteConfirmationModal from "@/components/admin/DeleteConfirmationModal";
 
+type CategoryRow = {
+  id: string;
+  name: string;
+  image: string | null;
+};
+
 type CategoriesTableProps = {
-  initialCategories: Category[];
+  initialCategories: CategoryRow[];
 };
 
 export default function CategoriesTable({
   initialCategories,
 }: CategoriesTableProps) {
-  const [categories, setCategories] = useState<Category[]>(initialCategories);
+  const [categories, setCategories] =
+    useState<CategoryRow[]>(initialCategories);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [categoryToDelete, setCategoryToDelete] = useState<Category | null>(
+  const [categoryToDelete, setCategoryToDelete] = useState<CategoryRow | null>(
     null,
   );
   const [isDeleting, setIsDeleting] = useState(false);
@@ -23,7 +29,7 @@ export default function CategoriesTable({
   const hasCategories = categories.length > 0;
   const totalCategories = useMemo(() => categories.length, [categories]);
 
-  const handleDeleteButtonClick = (category: Category) => {
+  const handleDeleteButtonClick = (category: CategoryRow) => {
     setCategoryToDelete(category);
     setDeleteError(null);
     setShowDeleteModal(true);


### PR DESCRIPTION
## Summary
Fix bug where admin could not delete unnecessary categories because no delete action was available on the Categories page.

## Problem
The Categories page displayed existing categories, but there was no visible delete action in the UI. As a result, admins could not remove unnecessary categories.

## Solution
- added delete action/icon for category rows in `CategoriesTable.tsx`
- connected deletion to existing server-side delete flow
- added confirmation before deletion
- updated categories list in UI after successful delete
- added controlled error handling when deletion is blocked by server constraints

## Server-side behavior
- deletion uses existing logic in `delete-category.ts`
- foreign key constraint errors are converted into user-friendly UI messages
- API / route handling stays consistent with current architecture

## Result
- admins can now delete categories from the Categories page
- list updates without manual page reload
- blocked deletions show a clear error instead of breaking the page

Closes #188