### PR TITLE
fix(admin-185): add validation for category name and image URL

### DIFF
--- a/src/app/api/actions-category/create-category.ts
+++ b/src/app/api/actions-category/create-category.ts
@@ -5,6 +5,10 @@ import { db } from "@/db/db";
 import { revalidatePath } from "next/cache";
 import { requireAdmin } from "@/lib/auth/requireAdmin";
 import { redirect } from "next/navigation";
+import {
+  validateCategoryName,
+  validateImageUrl,
+} from "@/lib/category-validation";
 
 type CategoryFormValues = {
   name: string;
@@ -76,6 +80,23 @@ export async function createCategoryAction(
   formData: FormData,
 ): Promise<CreateCategoryState> {
   const values = getCategoryFormValues(formData);
+
+  // Client-side validation on server
+  const nameError = validateCategoryName(values.name);
+  if (nameError) {
+    return {
+      error: nameError,
+      values,
+    };
+  }
+
+  const imageError = validateImageUrl(values.image);
+  if (imageError) {
+    return {
+      error: imageError,
+      values,
+    };
+  }
 
   try {
     await createCategoryRecord(values);

--- a/src/components/admin/AddCategoryForm.tsx
+++ b/src/components/admin/AddCategoryForm.tsx
@@ -4,7 +4,13 @@ import {
   createCategoryAction,
   type CreateCategoryState,
 } from "@/app/api/actions-category/create-category";
-import { useActionState } from "react";
+import {
+  validateCategoryName,
+  validateImageUrl,
+  isValidCategoryNameInput,
+  isValidImageUrlInput,
+} from "@/lib/category-validation";
+import { useActionState, useState } from "react";
 
 const initialState: CreateCategoryState = {
   error: null,
@@ -20,8 +26,67 @@ export default function AddCategoryForm() {
     initialState,
   );
 
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [imageError, setImageError] = useState<string | null>(null);
+  const [formValues, setFormValues] = useState({
+    name: state.values.name,
+    image: state.values.image,
+  });
+
+  const handleNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    setFormValues((prev) => ({ ...prev, name: value }));
+
+    // Allow any input, validate on blur
+    if (!isValidCategoryNameInput(value)) {
+      setNameError("Name contains unsupported special characters");
+    } else {
+      setNameError(null);
+    }
+  };
+
+  const handleNameBlur = () => {
+    const error = validateCategoryName(formValues.name);
+    setNameError(error);
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value;
+
+    setFormValues((prev) => ({ ...prev, image: value }));
+
+    // Allow any input, validate on blur
+    if (!isValidImageUrlInput(value)) {
+      setImageError("Image URL must start with http:// or https://");
+    } else {
+      setImageError(null);
+    }
+  };
+
+  const handleImageBlur = () => {
+    const error = validateImageUrl(formValues.image);
+    setImageError(error);
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    const nameValidationError = validateCategoryName(formValues.name);
+    const imageValidationError = validateImageUrl(formValues.image);
+
+    setNameError(nameValidationError);
+    setImageError(imageValidationError);
+
+    if (nameValidationError || imageValidationError) {
+      e.preventDefault();
+    }
+  };
+
   return (
-    <form action={formAction} className="grid gap-4 md:grid-cols-2">
+    <form
+      action={formAction}
+      onSubmit={handleSubmit}
+      className="grid gap-4 md:grid-cols-2"
+    >
       <div>
         <label className="mb-2 block text-sm font-medium text-gray-700">
           Name
@@ -30,10 +95,17 @@ export default function AddCategoryForm() {
           name="name"
           type="text"
           placeholder="Category name"
-          className="w-full rounded border p-3"
-          defaultValue={state.values.name}
+          className={`w-full rounded border p-3 ${nameError ? "border-red-500" : "border-gray-300"}`}
+          value={formValues.name}
+          onChange={handleNameChange}
+          onBlur={handleNameBlur}
           required
         />
+        {nameError && (
+          <p className="mt-1 text-sm text-red-600" role="alert">
+            {nameError}
+          </p>
+        )}
       </div>
 
       <div>
@@ -44,10 +116,17 @@ export default function AddCategoryForm() {
           name="image"
           type="text"
           placeholder="https://example.com/category.jpg"
-          className="w-full rounded border p-3"
-          defaultValue={state.values.image}
+          className={`w-full rounded border p-3 ${imageError ? "border-red-500" : "border-gray-300"}`}
+          value={formValues.image}
+          onChange={handleImageChange}
+          onBlur={handleImageBlur}
           required
         />
+        {imageError && (
+          <p className="mt-1 text-sm text-red-600" role="alert">
+            {imageError}
+          </p>
+        )}
       </div>
 
       <div className="md:col-span-2 min-h-6">
@@ -59,7 +138,11 @@ export default function AddCategoryForm() {
       </div>
 
       <div className="md:col-span-2">
-        <button type="submit" className="rounded bg-black px-5 py-3 text-white">
+        <button
+          type="submit"
+          disabled={!!nameError || !!imageError}
+          className="rounded bg-black px-5 py-3 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+        >
           Create Category
         </button>
       </div>

--- a/src/lib/category-validation.ts
+++ b/src/lib/category-validation.ts
@@ -1,0 +1,39 @@
+const CATEGORY_NAME_INPUT_REGEX = /^[a-zA-Zа-яА-ЯіІїЇєЄґҐ0-9\s]*$/;
+const CATEGORY_NAME_REGEX = /^[a-zA-Zа-яА-ЯіІїЇєЄґҐ0-9\s]+$/;
+const URL_REGEX = /^https?:\/\/.+/;
+
+export function isValidCategoryNameInput(value: string) {
+  return CATEGORY_NAME_INPUT_REGEX.test(value);
+}
+
+export function isValidImageUrlInput(value: string) {
+  return value === "" || URL_REGEX.test(value);
+}
+
+export function validateCategoryName(name: string) {
+  const trimmedName = name.trim();
+
+  if (!trimmedName) {
+    return "Name is required";
+  }
+
+  if (!CATEGORY_NAME_REGEX.test(trimmedName)) {
+    return "Name can only contain letters, numbers, and spaces";
+  }
+
+  return null;
+}
+
+export function validateImageUrl(url: string) {
+  const trimmedUrl = url.trim();
+
+  if (!trimmedUrl) {
+    return "Image URL is required";
+  }
+
+  if (!URL_REGEX.test(trimmedUrl)) {
+    return "Image URL must start with http:// or https://";
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Add validation for category creation to prevent invalid name and image URL input.

## Problem
The Add Category form allowed invalid data:
- `name` accepted unsupported special characters (e.g. !!!, ###)
- `image` accepted invalid URLs (e.g. "http", "test")

This could lead to incorrect data being stored in the database.

## Solution

### Client-side validation
- added validation in `AddCategoryForm.tsx`
- rules:
  - `name`: only letters, numbers and spaces
  - `image`: must be a valid URL (http/https)
- form behavior:
  - prevents submission on invalid input
  - shows clear error messages
  - preserves user input

### Server-side validation
- added validation in `create-category.ts`
- ensures invalid data cannot be saved even if UI is bypassed
- returns meaningful error messages instead of failing silently

### Shared validation
- extracted reusable rules into `category-validation.ts`
- ensures consistency between client and server

## Result
- invalid categories can no longer be created
- improved data integrity in database
- better UX with clear feedback
- consistent validation across frontend and backend

Closes #185