### PR TITLE
fix(admin-206): update order count on admin dashboard after booking changes

### DIFF
--- a/src/app/api/actions-booking/create-booking.ts
+++ b/src/app/api/actions-booking/create-booking.ts
@@ -6,7 +6,6 @@ import { revalidatePath } from "next/cache";
 
 export async function createBooking(formData: FormData) {
   try {
-  
     const userId = formData.get("userId")?.toString() || "";
     const bikeId = formData.get("bikeId")?.toString() || "";
     const firstName = formData.get("firstName")?.toString() || "";
@@ -17,11 +16,19 @@ export async function createBooking(formData: FormData) {
     const endDate = formData.get("endDate")?.toString() || "";
     const totalPrice = formData.get("totalPrice")?.toString() || "";
 
-    
-    if (!userId || !bikeId || !firstName || !lastName || !email || !phone || !startDate || !endDate || !totalPrice) {
+    if (
+      !userId ||
+      !bikeId ||
+      !firstName ||
+      !lastName ||
+      !email ||
+      !phone ||
+      !startDate ||
+      !endDate ||
+      !totalPrice
+    ) {
       throw new Error("Missing required fields");
     }
-
 
     await db.insert(bookings).values({
       userId: userId,
@@ -35,12 +42,12 @@ export async function createBooking(formData: FormData) {
       totalPrice: totalPrice,
     });
 
+    revalidatePath("/admin");
     revalidatePath("/admin/bookings");
     return { success: true };
-
   } catch (err: unknown) {
-   
-    const errorMessage = err instanceof Error ? err.message : "Failed to create booking";
+    const errorMessage =
+      err instanceof Error ? err.message : "Failed to create booking";
     console.error("Create Booking Error:", errorMessage);
     throw new Error(errorMessage);
   }

--- a/src/app/api/actions-booking/delete-booking.ts
+++ b/src/app/api/actions-booking/delete-booking.ts
@@ -11,15 +11,15 @@ export async function deleteBooking(id: string) {
       throw new Error("Booking ID is required for deletion");
     }
 
-   
     await db.delete(bookings).where(eq(bookings.id, id));
 
-    
+    revalidatePath("/admin");
     revalidatePath("/admin/bookings");
 
     return { success: true };
   } catch (err: unknown) {
-    const errorMessage = err instanceof Error ? err.message : "Failed to delete booking";
+    const errorMessage =
+      err instanceof Error ? err.message : "Failed to delete booking";
     console.error("Delete Booking Error:", errorMessage);
     throw new Error(errorMessage);
   }

--- a/src/app/api/actions-booking/update-booking.ts
+++ b/src/app/api/actions-booking/update-booking.ts
@@ -7,7 +7,6 @@ import { revalidatePath } from "next/cache";
 
 export async function updateBooking(id: string, formData: FormData) {
   try {
-   
     const startDate = formData.get("startDate")?.toString();
     const endDate = formData.get("endDate")?.toString();
     const totalPrice = formData.get("totalPrice")?.toString();
@@ -16,11 +15,9 @@ export async function updateBooking(id: string, formData: FormData) {
     const email = formData.get("email")?.toString();
     const phone = formData.get("phone")?.toString();
 
-    
     if (!id) {
       throw new Error("Booking ID is required for update");
     }
-
 
     await db
       .update(bookings)
@@ -35,12 +32,13 @@ export async function updateBooking(id: string, formData: FormData) {
       })
       .where(eq(bookings.id, id));
 
-    
+    revalidatePath("/admin");
     revalidatePath("/admin/bookings");
-    
+
     return { success: true };
   } catch (err: unknown) {
-    const errorMessage = err instanceof Error ? err.message : "Failed to update booking";
+    const errorMessage =
+      err instanceof Error ? err.message : "Failed to update booking";
     console.error("Update Booking Error:", errorMessage);
     throw new Error(errorMessage);
   }

--- a/src/app/api/booking/create/route.ts
+++ b/src/app/api/booking/create/route.ts
@@ -7,6 +7,7 @@ import { authOptions } from "@/lib/auth/auth-options";
 import { bookingSchema } from "@/lib/schemas/auth-schema";
 import { NextResponse } from "next/server";
 import { bookingAccessories } from "@/db/tables/booking-accessories";
+import { revalidatePath } from "next/cache";
 
 export async function GET(req: Request) {
   try {
@@ -125,6 +126,8 @@ export async function POST(req: Request) {
 
       await db.insert(bookingAccessories).values(accessoryData);
     }
+
+    revalidatePath("/admin");
 
     return NextResponse.json(
       { success: true, bookingId: newBooking.id },

--- a/src/components/admin/AdminPanel.tsx
+++ b/src/components/admin/AdminPanel.tsx
@@ -49,7 +49,9 @@ export default function AdminPanel() {
   };
 
   const loadActiveOrders = async () => {
-    const res = await fetch("/api/actions-booking?mode=all");
+    const res = await fetch("/api/actions-booking?mode=all", {
+      cache: "no-store",
+    });
     const data = await res.json();
     const bookings: BookingItem[] = Array.isArray(data) ? data : [];
     const today = toLocalDateString(new Date());


### PR DESCRIPTION
## Summary
Fix issue where the order count on the Admin Dashboard was not updating after creating, updating, or deleting bookings.

## Changes
- Added revalidation logic after booking mutations:
  - create-booking
  - update-booking
  - delete-booking
  - booking API route
- Ensured Admin Dashboard fetches актуальные данные после изменений
- Updated AdminPanel to display correct and up-to-date order count

## Result
- Order count now updates correctly after any booking changes
- Admin Dashboard always reflects actual data from the database
- No page reload required

## Risk
Low — changes are limited to booking flow and admin dashboard data refresh logic

## Related issue
#206