### PR TITLE
fix(admin-194): allow consecutive bike deletion without page refresh

### DIFF
--- a/src/components/admin/BikesTable.tsx
+++ b/src/components/admin/BikesTable.tsx
@@ -47,6 +47,7 @@ export default function BikesTable({
       await deleteBike(bikeToDelete);
       setShowDeleteModal(false);
       setBikeToDelete(null);
+      setIsDeleting(false);
       await onDeleteSuccess();
     } catch (error) {
       console.error("Delete failed:", error);


### PR DESCRIPTION
## Summary
Fix bug where deleting one bike prevented deleting the next bike without refreshing the page.

## Problem
After deleting a bike in the admin bikes table, the next delete action became unavailable because local delete state was not reset correctly.

## Changes
- updated `BikesTable.tsx`
- fixed local `isDeleting` state reset after delete action
- kept existing API calls and component interfaces unchanged

## Result
- multiple bikes can now be deleted consecutively
- no manual page refresh is required
- delete dialog/button works correctly for each next deletion

Closes #194