### PR TITLE
fix(admin-222): show user-friendly message for duplicate accessory

### DIFF
--- a/src/app/api/actions-accessory/create-accessory.ts
+++ b/src/app/api/actions-accessory/create-accessory.ts
@@ -10,6 +10,30 @@ import {
   validateAccessoryPrice,
 } from "@/lib/accessory-validation";
 
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  if ("cause" in error) {
+    return getErrorCode((error as { cause: unknown }).cause);
+  }
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error ?? "");
+}
+
+function isUniqueConstraintError(error: unknown) {
+  if (getErrorCode(error) === "23505") return true;
+  const msg = getErrorMessage(error).toLowerCase();
+  return msg.includes("duplicate key") || msg.includes("unique constraint");
+}
+
 export default async function createAccessory(formData: FormData) {
   await requireAdmin();
 
@@ -17,19 +41,20 @@ export default async function createAccessory(formData: FormData) {
   const pricePerDayRaw = String(formData.get("price_per_day") ?? "").trim();
 
   const nameError = validateAccessoryName(name);
-
-  if (nameError) {
-    throw new Error(nameError);
-  }
+  if (nameError) throw new Error(nameError);
 
   const priceError = validateAccessoryPrice(pricePerDayRaw);
-
-  if (priceError) {
-    throw new Error(priceError);
-  }
+  if (priceError) throw new Error(priceError);
 
   const pricePerDay = normalizeAccessoryPrice(pricePerDayRaw);
 
-  await db.insert(accessories).values({ name, pricePerDay });
+  try {
+    await db.insert(accessories).values({ name, pricePerDay });
+  } catch (err: unknown) {
+    if (isUniqueConstraintError(err)) {
+      throw new Error("Accessory with this name already exists");
+    }
+    throw err;
+  }
   revalidatePath("/admin");
 }

--- a/src/app/api/actions-accessory/update-accessory.ts
+++ b/src/app/api/actions-accessory/update-accessory.ts
@@ -11,6 +11,30 @@ import {
   validateAccessoryPrice,
 } from "@/lib/accessory-validation";
 
+function getErrorCode(error: unknown): string | null {
+  if (typeof error !== "object" || error === null) {
+    return null;
+  }
+  if ("code" in error && typeof error.code === "string") {
+    return error.code;
+  }
+  if ("cause" in error) {
+    return getErrorCode((error as { cause: unknown }).cause);
+  }
+  return null;
+}
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error ?? "");
+}
+
+function isUniqueConstraintError(error: unknown) {
+  if (getErrorCode(error) === "23505") return true;
+  const msg = getErrorMessage(error).toLowerCase();
+  return msg.includes("duplicate key") || msg.includes("unique constraint");
+}
+
 export default async function updateAccessory(id: string, formData: FormData) {
   await requireAdmin();
 
@@ -18,22 +42,23 @@ export default async function updateAccessory(id: string, formData: FormData) {
   const pricePerDayRaw = String(formData.get("price_per_day") ?? "").trim();
 
   const nameError = validateAccessoryName(name);
-
-  if (nameError) {
-    throw new Error(nameError);
-  }
+  if (nameError) throw new Error(nameError);
 
   const priceError = validateAccessoryPrice(pricePerDayRaw);
-
-  if (priceError) {
-    throw new Error(priceError);
-  }
+  if (priceError) throw new Error(priceError);
 
   const pricePerDay = normalizeAccessoryPrice(pricePerDayRaw);
 
-  await db
-    .update(accessories)
-    .set({ name, pricePerDay })
-    .where(eq(accessories.id, id));
+  try {
+    await db
+      .update(accessories)
+      .set({ name, pricePerDay })
+      .where(eq(accessories.id, id));
+  } catch (err: unknown) {
+    if (isUniqueConstraintError(err)) {
+      throw new Error("Accessory with this name already exists");
+    }
+    throw err;
+  }
   revalidatePath("/admin");
 }


### PR DESCRIPTION
Fixes issue where creating an accessory with an existing name displayed a raw database error instead of a user-friendly message.

Changes:
- Added handling for Postgres unique constraint error (23505)
- Introduced helper to extract error codes from DB errors
- Replaced raw DB error with a user-friendly validation message

Notes:
- No UI changes required
- Existing error handling flow preserved (server → route → modal)
- No impact on other components or features

Closes #222